### PR TITLE
allow harvesting crops

### DIFF
--- a/register_bot.lua
+++ b/register_bot.lua
@@ -177,7 +177,8 @@ local function bot_dig(pos,digy)
         local drop = minetest.get_node(digpos)		
         local node_definition = minetest.registered_nodes[drop.name]
         local drops = minetest.get_node_drops(drop.name)
-        if node_definition.groups.not_in_creative_inventory~=1 then
+        if (node_definition.groups.not_in_creative_inventory~=1
+            or node_definition.drawtype == "plantlike") then
             local inv=minetest.get_inventory({
                                     type="node",
                                     pos=pos


### PR DESCRIPTION
I noticed it was not possible to harvest crops (for example wheat or cotton in minetest-game) using the bot because it would not process the drop. This was due to the check in line 180. I extended the condition and it is now possible to harvest using this patch.

By this incidence, I'd like to ask what the check for creative inventory inclusion in line 180 is required for anyway. I could imagine it can block more situations where the bot should be used to collect objects that are created through processes in the world.

I'm currently investigating further to identify why it is still not possible to also plant seeds using the bot. If this can also be implemented, the bot could be used for all the steps of farming crops.